### PR TITLE
Override config with env if flag is set

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -3,4 +3,6 @@ package flags
 const (
 	ConfigPath        = "config-path"
 	DefaultConfigPath = "config.toml"
+	EnvOverride       = "env-override"
+	EnvOverridePrefix = "prefix"
 )

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -54,15 +54,11 @@ func StartCmdWithOptions[C any](app coreapp.App[C], defaultAppHome string, _ Sta
 				return err
 			}
 
-			if envOverride {
-				envOverridePrefix, err := cmd.Flags().GetString(flags.EnvOverridePrefix)
-				if err != nil {
-					return err
-				}
-				if err = toml.PrioritizeEnv[config.Config[C]](configPath, envOverridePrefix, &cfg); err != nil {
-					return err
-				}
-			} else if err = toml.ReadIntoMap[config.Config[C]](configPath, &cfg); err != nil {
+			envOverridePrefix, err := cmd.Flags().GetString(flags.EnvOverridePrefix)
+			if err != nil {
+				return err
+			}
+			if err = toml.LoadConfig[config.Config[C]](configPath, &cfg, envOverride, envOverridePrefix); err != nil {
 				return err
 			}
 

--- a/config/toml/toml.go
+++ b/config/toml/toml.go
@@ -6,17 +6,9 @@ import (
 	"github.com/spf13/viper"
 )
 
-// ReadTomlIntoMap reads a TOML file into a map.
-func ReadIntoMap[T any](filepath string, target *T) error {
-	return initConfig(filepath, false, "", target)
-}
-
-// PrioritizeEnv prioritizes environment variables over config file values.
-func PrioritizeEnv[T any](filepath string, envPrefix string, target *T) error {
-	return initConfig(filepath, true, envPrefix, target)
-}
-
-func initConfig[T any](filepath string, envOverride bool, envPrefix string, target *T) error {
+// LoadConfig loads a TOML config file into the target. It will prioritize
+// environment variables if envOverride is true.
+func LoadConfig[T any](filepath string, target *T, envOverride bool, envPrefix string) error {
 	// Find and read the config file
 	viper.SetConfigFile(filepath)
 

--- a/config/toml/toml.go
+++ b/config/toml/toml.go
@@ -1,18 +1,35 @@
 package toml
 
 import (
-	"bytes"
-	"os"
+	"strings"
 
-	"github.com/pelletier/go-toml"
+	"github.com/spf13/viper"
 )
 
 // ReadTomlIntoMap reads a TOML file into a map.
 func ReadIntoMap[T any](filepath string, target *T) error {
-	data, err := os.ReadFile(filepath)
-	if err != nil {
+	return initConfig(filepath, false, "", target)
+}
+
+// PrioritizeEnv prioritizes environment variables over config file values.
+func PrioritizeEnv[T any](filepath string, envPrefix string, target *T) error {
+	return initConfig(filepath, true, envPrefix, target)
+}
+
+func initConfig[T any](filepath string, envOverride bool, envPrefix string, target *T) error {
+	// Find and read the config file
+	viper.SetConfigFile(filepath)
+
+	if envOverride {
+		// Enable viper to read Environment Variables
+		viper.AutomaticEnv()
+		viper.SetEnvPrefix(envPrefix)
+		viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	}
+
+	if err := viper.ReadInConfig(); err != nil {
 		return err
 	}
 
-	return toml.NewDecoder(bytes.NewReader(data)).Decode(target)
+	return viper.Unmarshal(target)
 }

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/golangci/golangci-lint v1.53.3
 	github.com/hashicorp/golang-lru/v2 v2.0.4
-	github.com/pelletier/go-toml v1.9.5
 	github.com/prometheus/client_golang v1.16.0
 	github.com/rs/zerolog v1.29.1
 	github.com/spf13/cobra v1.7.0
+	github.com/spf13/viper v1.12.0
 )
 
 require (
@@ -127,6 +127,7 @@ require (
 	github.com/nishanths/predeclared v0.2.2 // indirect
 	github.com/nunnatsa/ginkgolinter v0.12.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v1.4.2 // indirect
@@ -155,7 +156,6 @@ require (
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/spf13/viper v1.12.0 // indirect
 	github.com/ssgreg/nlreturn/v2 v2.2.1 // indirect
 	github.com/stbenjam/no-sprintf-host-port v0.1.1 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect


### PR DESCRIPTION
Added an option for app to read config from env first.
This is needed for deployment to populate the configs with correct envs

i.e
```console
export BTS_APP_POSTGRESDB_HOST="my_k8s_host" 
app start --env-override --prefix=bts
```
this will load
`config.App.PostgresDB.Host = "my_k8s_host"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added the ability to override configuration settings using environment variables. This feature introduces two new flags, `EnvOverride` and `EnvOverridePrefix`, which can be used to specify whether environment variable overrides should be enabled and what prefix should be used for the environment variables.
- Refactor: Updated the `ReadIntoMap` function in the `config/toml` package to support environment variable overrides. A new function, `PrioritizeEnv`, has been added to prioritize environment variables when reading the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->