### PR TITLE
fix(jobs): Run polling jobs on startup before sleeping

### DIFF
--- a/baseapp/job_manager.go
+++ b/baseapp/job_manager.go
@@ -164,7 +164,7 @@ func (jm *JobManager) RunProducers(gctx context.Context) { //nolint:gocognit // 
 			continue
 		} else if subJob, ok := j.(job.Subscribable); ok {
 			// Handle unmigrated jobs. // TODO: migrate format.
-			jm.jobExecutors.Submit(func() {
+			jm.jobProducers.Submit(func() {
 				ch := subJob.Subscribe(ctx)
 				for {
 					select {
@@ -179,7 +179,7 @@ func (jm *JobManager) RunProducers(gctx context.Context) { //nolint:gocognit // 
 			})
 			// Handle unmigrated jobs. // TODO: migrate format.
 		} else if ethSubJob, ok := j.(job.EthSubscribable); ok { //nolint:govet // todo fix.
-			jm.jobExecutors.Submit(func() {
+			jm.jobProducers.Submit(func() {
 				sub, ch := ethSubJob.Subscribe(ctx)
 				for {
 					select {
@@ -198,7 +198,7 @@ func (jm *JobManager) RunProducers(gctx context.Context) { //nolint:gocognit // 
 				}
 			})
 		} else if blockHeaderJob, ok := j.(job.BlockHeaderSub); ok { //nolint:govet // todo fix.
-			jm.jobExecutors.Submit(func() {
+			jm.jobProducers.Submit(func() {
 				sub, ch := blockHeaderJob.Subscribe(ctx)
 				for {
 					select {

--- a/job/types.go
+++ b/job/types.go
@@ -80,16 +80,6 @@ type conditional struct {
 // ConditionalProducer produces a job when the condition is met.
 func (cj *conditional) Producer(ctx context.Context, pool WorkerPool) error {
 	for {
-		// NOTE: for job producers, we can just register the default, pass all of
-		// them into `TaskGroups` have the context be shared and bobs your uncle
-		// we get all this for free.
-		// Sleep for a period of time.
-		time.Sleep(cj.IntervalTime(ctx))
-		// args := func() any {
-		// 	time.Sleep(cj.IntervalTime(ctx))
-		// 	return nil
-		// }()
-
 		select {
 		// If the context is cancelled, return.
 		case <-ctx.Done():
@@ -100,6 +90,16 @@ func (cj *conditional) Producer(ctx context.Context, pool WorkerPool) error {
 				pool.Submit(jobtypes.NewPayload(ctx, cj, nil).Execute)
 			}
 		}
+
+		// NOTE: for job producers, we can just register the default, pass all of
+		// them into `TaskGroups` have the context be shared and bobs your uncle
+		// we get all this for free.
+		// Sleep for a period of time.
+		time.Sleep(cj.IntervalTime(ctx))
+		// args := func() any {
+		// 	time.Sleep(cj.IntervalTime(ctx))
+		// 	return nil
+		// }()
 	}
 }
 


### PR DESCRIPTION
This allows jobs that have large polling intervals to run once upon startup of the app, rather than waiting to run until the first interval passes.