### PR TITLE
fix(jobs): Stop the Job Producer worker pool without waiting

### DIFF
--- a/baseapp/job_manager.go
+++ b/baseapp/job_manager.go
@@ -116,7 +116,7 @@ func (jm *JobManager) Stop() {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		jm.jobProducers.StopAndWait()
+		jm.jobProducers.Stop()
 		jm.jobProducers = nil
 	}()
 

--- a/worker/pool.go
+++ b/worker/pool.go
@@ -48,3 +48,12 @@ func (p *Pool) StopAndWait() {
 	defer p.Logger().Info("workers finished")
 	p.WorkerPool.StopAndWait()
 }
+
+// Stop stops the pool without waiting for all workers to finish. NOTE: Tasks being executed by
+// workers will continue until completion (unless the process is terminated). Tasks in the queue
+// will not be executed.
+func (p *Pool) Stop() {
+	p.Logger().Info("stopping worker pool")
+	defer p.Logger().Info("workers halted")
+	p.WorkerPool.Stop()
+}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Refactor: Updated the job management system to stop tasks more efficiently. This change may lead to quicker shutdown times, but it won't wait for all tasks to complete before stopping.
- New Feature: Added a 'Stop' function to the worker pool, allowing for a more immediate halt of operations. This feature enhances control over task execution but may leave some tasks unfinished.
- Refactor: Improved logging for task completion, providing clearer insights into the system's operation and task finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->