### PR TITLE
cleaning up some code. Remove redundant job interface

### DIFF
--- a/baseapp/job_manager.go
+++ b/baseapp/job_manager.go
@@ -156,7 +156,7 @@ func (jm *JobManager) runProducer(ctx context.Context, j job.Basic) bool {
 }
 
 // RunProducers sets up each job and runs its producer.
-func (jm *JobManager) RunProducers(gctx context.Context) { //nolint:gocognit // todo fix.
+func (jm *JobManager) RunProducers(gctx context.Context) {
 	for _, j := range jm.jobRegistry.Iterate() {
 		ctx := jm.ctxFactory.NewSDKContext(gctx)
 		if sj, ok := j.(job.HasSetup); ok {
@@ -165,7 +165,7 @@ func (jm *JobManager) RunProducers(gctx context.Context) { //nolint:gocognit // 
 			}
 		}
 
-		if jm.runProducer(ctx, j) { //nolint:nestif // todo fix.
+		if jm.runProducer(ctx, j) {
 			continue
 		} else if subJob, ok := j.(job.Subscribable); ok {
 			jm.jobProducers.Submit(func() {
@@ -181,7 +181,7 @@ func (jm *JobManager) RunProducers(gctx context.Context) { //nolint:gocognit // 
 					}
 				}
 			})
-		} else if ethSubJob, ok := j.(job.EthSubscribable); ok {
+		} else if ethSubJob, okEthSubJob := j.(job.EthSubscribable); okEthSubJob {
 			jm.runEthSubscribable(ctx, ethSubJob)
 		} else {
 			panic(fmt.Sprintf("unknown job type %s", reflect.TypeOf(j)))

--- a/baseapp/job_manager.go
+++ b/baseapp/job_manager.go
@@ -193,7 +193,7 @@ func (jm *JobManager) runEthSubscribable(ctx context.Context, j job.EthSubscriba
 	jm.jobProducers.Submit(withRetry(func() bool {
 		sub, ch, err := j.Subscribe(ctx)
 		if err != nil {
-			jm.Logger(ctx).Error("error subscribing block header", "err", err)
+			jm.Logger(ctx).Error("error in eth subscription", "err", err)
 			return true
 		}
 
@@ -203,7 +203,7 @@ func (jm *JobManager) runEthSubscribable(ctx context.Context, j job.EthSubscriba
 				j.Unsubscribe(ctx)
 				return false
 			case err = <-sub.Err():
-				jm.Logger(ctx).Error("error in subscription", "err", err)
+				jm.Logger(ctx).Error("error in eth subscription", "err", err)
 				j.Unsubscribe(ctx)
 				return true
 			case val := <-ch:
@@ -224,7 +224,7 @@ func withRetry(task func() bool, logger log.Logger) func() {
 				// Exponential backoff with jitter.
 				jitter, _ := rand.Int(rand.Reader, big.NewInt(jitterRange))
 				sleep := backoff + time.Duration(jitter.Int64())*time.Millisecond
-				logger.Info("retrying job", "backoff", sleep, "task", task)
+				logger.Info(fmt.Sprintf("retrying task in %s...", sleep))
 				time.Sleep(sleep)
 				backoff *= backoffBase
 				if backoff > maxBackoff {

--- a/job/types.go
+++ b/job/types.go
@@ -7,7 +7,6 @@ import (
 	jobtypes "github.com/berachain/offchain-sdk/job/types"
 
 	"github.com/ethereum/go-ethereum"
-	coretypes "github.com/ethereum/go-ethereum/core/types"
 )
 
 // WrapJob wraps a basic job into a job that can be submitted to the worker pool.
@@ -108,13 +107,6 @@ type Subscribable interface {
 // EthSubscribable represents a subscription to an ethereum event.
 type EthSubscribable interface {
 	Basic
-	Subscribe(ctx context.Context) (ethereum.Subscription, chan coretypes.Log, error)
-	Unsubscribe(ctx context.Context)
-}
-
-// BlockHeaderSub represents a block watcher job.
-type BlockHeaderSub interface {
-	Basic
-	Subscribe(ctx context.Context) (ethereum.Subscription, chan *coretypes.Header, error)
+	Subscribe(ctx context.Context) (ethereum.Subscription, chan any, error)
 	Unsubscribe(ctx context.Context)
 }

--- a/x/jobs/block_header_job.go
+++ b/x/jobs/block_header_job.go
@@ -43,8 +43,17 @@ func (w *BlockHeaderWatcher) Subscribe(
 	sCtx.Logger().Info("Subscribed to new block headers")
 	ch := make(chan any)
 	go func() {
-		for val := range headerCh {
-			ch <- val
+		defer close(ch)
+		for {
+			select {
+			case val, ok := <-headerCh:
+				if !ok {
+					return
+				}
+				ch <- val
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 

--- a/x/jobs/block_header_job.go
+++ b/x/jobs/block_header_job.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 )
 
-// Compile time check to ensure that BlockHeaderWatcher implements job.BlockHeaderSub, and
+// Compile time check to ensure that BlockHeaderWatcher implements job.EthSubscribable, and
 // optionally the basic job's Setup and Teardown methods.
 var (
 	_ job.EthSubscribable = (*BlockHeaderWatcher)(nil)

--- a/x/jobs/event_filter_job.go
+++ b/x/jobs/event_filter_job.go
@@ -48,8 +48,17 @@ func (j *EthFilterSub) Subscribe(
 
 	ch := make(chan any)
 	go func() {
-		for val := range logCh {
-			ch <- val
+		defer close(ch)
+		for {
+			select {
+			case val, ok := <-logCh:
+				if !ok {
+					return
+				}
+				ch <- val
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 

--- a/x/jobs/event_job.go
+++ b/x/jobs/event_job.go
@@ -54,8 +54,17 @@ func (j *EthEventSub) Subscribe(
 
 	ch := make(chan any)
 	go func() {
-		for val := range logCh {
-			ch <- val
+		defer close(ch)
+		for {
+			select {
+			case val, ok := <-logCh:
+				if !ok {
+					return
+				}
+				ch <- val
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
 


### PR DESCRIPTION
1. Removed job type `BlockHeaderSub` since `EthSubscribable` pretty much does the same thing.
2. Changed channel type to `chan any`. The downstream already handles type conversion in `Execute(context.Context, any)`
3. Added retry log to have more visibility when subscription retries on failure
 
Above change is tested in [bts](https://github.com/berachain/bts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced the job management system to improve handling of Ethereum-based subscription jobs.
  - Streamlined the retry mechanism with better logging for increased transparency during error recovery.

- **Bug Fixes**
  - Fixed an issue with the subscription interface to ensure compatibility with a wider range of data types.

- **Documentation**
  - Updated method signatures to reflect new return types and parameters for clarity in usage.

- **Chores**
  - Removed unused interfaces and methods to simplify the codebase and improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->