### PR TITLE
feat(transactor): Allow tracking times of fired messages

### DIFF
--- a/core/transactor/sender/types.go
+++ b/core/transactor/sender/types.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/berachain/offchain-sdk/client/eth"
 	"github.com/berachain/offchain-sdk/core/transactor/types"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -19,22 +18,21 @@ type (
 
 	// Tracker is an interface for tracking sent transactions.
 	Tracker interface {
-		SetClient(chain eth.Client)
-		Track(ctx context.Context, tx *coretypes.Transaction, msgIDs []string)
+		Track(context.Context, *coretypes.Transaction, []string, []time.Time)
 	}
 
 	// Factory is an interface for signing transactions.
 	Factory interface {
 		BuildTransactionFromRequests(
-			ctx context.Context, forcedNonce uint64, txReqs ...*types.TxRequest,
+			context.Context, uint64, ...*types.TxRequest,
 		) (*coretypes.Transaction, error)
-		GetNextNonce(oldNonce uint64) (uint64, bool)
+		GetNextNonce(uint64) (uint64, bool)
 	}
 
 	// A RetryPolicy is used to determine if a transaction should be retried and how long to wait
 	// before retrying again.
 	RetryPolicy interface {
-		Get(tx *coretypes.Transaction, err error) (bool, time.Duration)
-		UpdateTxModified(oldTx, newTx common.Hash)
+		Get(*coretypes.Transaction, error) (bool, time.Duration)
+		UpdateTxModified(common.Hash, common.Hash)
 	}
 )

--- a/core/transactor/tracker.go
+++ b/core/transactor/tracker.go
@@ -64,7 +64,9 @@ func (t *TxrV2) OnStale(
 		"nonce", inFlightTx.Nonce(), "gas-price", inFlightTx.GasPrice(),
 	)
 
-	return t.sendAndTrack(ctx, inFlightTx.MsgIDs, types.NewTxRequestFromTx(inFlightTx))
+	return t.sendAndTrack(
+		ctx, inFlightTx.MsgIDs, inFlightTx.TimesFired, types.NewTxRequestFromTx(inFlightTx),
+	)
 }
 
 func (t *TxrV2) OnError(_ context.Context, tx *tracker.InFlightTx, _ error) {

--- a/core/transactor/tracker/subscription.go
+++ b/core/transactor/tracker/subscription.go
@@ -28,12 +28,12 @@ func (sub *Subscription) Start(ctx context.Context, ch chan *InFlightTx) error {
 			switch e.Status() {
 			case StatusSuccess:
 				// If the transaction was successful, call OnSuccess.
-				if err = sub.OnSuccess(e, e.Receipt); err != nil {
+				if err = sub.OnSuccess(e, e.receipt); err != nil {
 					sub.logger.Error("failed to handle successful tx", "err", err)
 				}
 			case StatusReverted:
 				// If the transaction was reverted, call OnRevert.
-				if err = sub.OnRevert(e, e.Receipt); err != nil {
+				if err = sub.OnRevert(e, e.receipt); err != nil {
 					sub.logger.Error("failed to handle reverted tx", "err", err)
 				}
 			case StatusStale:

--- a/core/transactor/tracker/tracker.go
+++ b/core/transactor/tracker/tracker.go
@@ -41,11 +41,13 @@ func (t *Tracker) SetClient(chain eth.Client) {
 }
 
 // Track adds a transaction to the in-flight list and waits for a status.
-func (t *Tracker) Track(ctx context.Context, tx *coretypes.Transaction, msgIDs []string) {
+func (t *Tracker) Track(
+	ctx context.Context, tx *coretypes.Transaction, msgIDs []string, timesFired []time.Time,
+) {
 	for _, msgID := range msgIDs {
 		t.inFlightTxs[msgID] = struct{}{}
 	}
-	inFlightTx := &InFlightTx{Transaction: tx, MsgIDs: msgIDs}
+	inFlightTx := &InFlightTx{Transaction: tx, MsgIDs: msgIDs, TimesFired: timesFired}
 	t.noncer.SetInFlight(inFlightTx)
 	go t.trackStatus(ctx, inFlightTx)
 }
@@ -152,7 +154,7 @@ func (t *Tracker) markConfirmed(tx *InFlightTx, receipt *coretypes.Receipt) {
 		receipt.ContractAddress = *contractAddr
 	}
 
-	tx.Receipt = receipt
+	tx.receipt = receipt
 	t.dispatchTx(tx)
 }
 

--- a/core/transactor/tracker/types.go
+++ b/core/transactor/tracker/types.go
@@ -3,6 +3,7 @@ package tracker
 import (
 	"context"
 	"strings"
+	"time"
 
 	coretypes "github.com/ethereum/go-ethereum/core/types"
 )
@@ -41,8 +42,11 @@ type Subscriber interface {
 // InFlightTx represents a transaction that is currently being tracked by the transactor.
 type InFlightTx struct {
 	*coretypes.Transaction
-	MsgIDs  []string
-	Receipt *coretypes.Receipt
+
+	MsgIDs     []string    // Message IDs that were included in the transaction.
+	TimesFired []time.Time // Times each message was initially fired.
+
+	receipt *coretypes.Receipt
 	isStale bool
 }
 
@@ -53,14 +57,14 @@ func (t *InFlightTx) ID() string {
 
 // Status returns the current status of a transaction owned by the transactor.
 func (t *InFlightTx) Status() Status {
-	if t.Receipt == nil {
+	if t.receipt == nil {
 		if t.isStale {
 			return StatusStale
 		}
 		return StatusPending
 	}
 
-	if t.Receipt.Status == 1 {
+	if t.receipt.Status == 1 {
 		return StatusSuccess
 	}
 

--- a/types/queue/sqs/sqs.go
+++ b/types/queue/sqs/sqs.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -92,13 +93,13 @@ func (q *Queue[T]) Push(item T) (string, error) {
 	}
 
 	// Add the message to the active set.
-	q.msgs.Store(*output.MessageId, struct{}{})
+	q.msgs.Store(*output.MessageId, time.Now())
 
 	return *output.MessageId, nil
 }
 
 // Pop retrieves an item from the SQS queue.
-func (q *Queue[T]) Receive() (string, T, bool) {
+func (q *Queue[T]) Receive() (string, T, time.Time, bool) {
 	var t2 T
 	t1 := reflect.TypeOf(t2).Elem()
 	newInstance := reflect.New(t1).Interface()
@@ -110,50 +111,50 @@ func (q *Queue[T]) Receive() (string, T, bool) {
 		MaxNumberOfMessages: 1,
 	})
 	if err != nil {
-		return "", t, false
+		return "", t, time.Time{}, false
 	}
 
 	// Check if a message was received
 	if len(resp.Messages) == 0 {
-		return "", t, false
+		return "", t, time.Time{}, false
 	}
 
 	// Unmarshal the message into a new instance of type T
 	if err = t.Unmarshal([]byte(*resp.Messages[0].Body)); err != nil {
-		return "", t, false
+		return "", t, time.Time{}, false
 	}
 
 	// Delete the message from the active set.
-	q.msgs.Delete(*resp.Messages[0].MessageId)
+	timeInserted, _ := q.msgs.LoadAndDelete(*resp.Messages[0].MessageId)
 
 	// Add to the inProcess MessageID queue, mark the Message as in Process.
 	// TODO memory growth atm.
 	q.inProcess[*resp.Messages[0].MessageId] = *resp.Messages[0].ReceiptHandle
 
-	return *resp.Messages[0].MessageId, t, true
+	return *resp.Messages[0].MessageId, t, timeInserted.(time.Time), true
 }
 
-func (q *Queue[T]) ReceiveMany(num int32) ([]string, []T, error) {
+func (q *Queue[T]) ReceiveMany(num int32) ([]string, []T, []time.Time, error) {
 	if num > awsMaxBatchSize {
 		num = awsMaxBatchSize
 	}
-
-	ts := make([]T, 0)
-	msgIDs := make([]string, 0)
 
 	// Receive a message from the SQS queue
 	resp, err := q.svc.ReceiveMessage(context.TODO(), &sqs.ReceiveMessageInput{
 		QueueUrl:            &q.queueURL,
 		MaxNumberOfMessages: num,
 	})
-
 	if err != nil {
-		return msgIDs, ts, err
+		return nil, nil, nil, err
 	}
 	// Check if a message was received
 	if len(resp.Messages) == 0 {
-		return msgIDs, ts, nil
+		return nil, nil, nil, err
 	}
+
+	msgIDs := make([]string, len(resp.Messages))
+	ts := make([]T, len(resp.Messages))
+	timesInserted := make([]time.Time, len(resp.Messages))
 
 	for _, m := range resp.Messages {
 		var t2 T
@@ -163,11 +164,12 @@ func (q *Queue[T]) ReceiveMany(num int32) ([]string, []T, error) {
 
 		// Unmarshal the message into a new instance of type T
 		if err = t.Unmarshal([]byte(*m.Body)); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		// Delete the message from the active set.
-		q.msgs.Delete(*m.MessageId)
+		timeInserted, _ := q.msgs.LoadAndDelete(*m.MessageId)
+		timesInserted = append(timesInserted, timeInserted.(time.Time))
 
 		// Add to the inProcess MessageID queue, mark the Message as in Process.
 		// TODO memory growth atm.
@@ -178,11 +180,8 @@ func (q *Queue[T]) ReceiveMany(num int32) ([]string, []T, error) {
 		ts = append(ts, t)
 		msgIDs = append(msgIDs, *m.MessageId)
 	}
-	if err != nil {
-		return nil, nil, err
-	}
 
-	return msgIDs, ts, nil
+	return msgIDs, ts, timesInserted, nil
 }
 
 func (q *Queue[T]) Len() int {

--- a/types/queue/types/types.go
+++ b/types/queue/types/types.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"time"
 )
 
 // Marshallable is an interface that defines the Marshal and Unmarshal methods.
@@ -15,8 +16,8 @@ type Marshallable interface {
 type Queue[T Marshallable] interface {
 	InQueue(messageID string) bool
 	Push(T) (string, error)
-	Receive() (string, T, bool)
-	ReceiveMany(num int32) ([]string, []T, error)
+	Receive() (string, T, time.Time, bool)
+	ReceiveMany(num int32) ([]string, []T, []time.Time, error)
 	Delete(string) error
 	Len() int
 }


### PR DESCRIPTION
Allows user of transactor to track times of when messages were initially fired out-of-the-box.