### PR TITLE
chore(transactor): Allow forcing txs through without queueing

### DIFF
--- a/client/eth/client.go
+++ b/client/eth/client.go
@@ -52,20 +52,22 @@ type Reader interface {
 
 		{
 			"pending": {
-				"0": {
+				"1": {
 					// transaction details...
-				}
+				},
+				...
 			},
 			"queued": {
-				"0": {
+				"3": {
 					// transaction details...
-				}
+				},
+				...
 			}
 		}
-
 	*/
 	TxPoolContentFrom(ctx context.Context, address common.Address) (
-		map[string]map[string]*ethcoretypes.Transaction, error)
+		map[string]map[string]*ethcoretypes.Transaction, error,
+	)
 
 	/*
 		TxPoolInspect returns the textual summary of all pending and queued transactions.
@@ -74,20 +76,19 @@ type Reader interface {
 		{
 			"pending": {
 				"0x12345": {
-					"0": "0x12345789: 1 wei + 2 gas x 3 wei"
-				}
+					"1": "0x12345789: 1 wei + 2 gas x 3 wei"
+				},
+				...
 			},
 			"queued": {
-				"0x12345": {
-					"0": "0x12345789: 1 wei + 2 gas x 3 wei"
-				}
+				"0x67890": {
+					"2": "0x12345789: 1 wei + 2 gas x 3 wei"
+				},
+				...
 			}
 		}
-
 	*/
-	TxPoolInspect(
-		ctx context.Context,
-	) (map[string]map[common.Address]map[string]string, error)
+	TxPoolInspect(ctx context.Context) (map[string]map[common.Address]map[string]string, error)
 }
 
 type Writer interface {

--- a/client/eth/client_provider.go
+++ b/client/eth/client_provider.go
@@ -261,14 +261,16 @@ Example response:
 
 	{
 		"pending": {
-		"0": {
-			// transaction details...
-		}
+			"1": {
+				// transaction details...
+			},
+			...
 		},
 		"queued": {
-		"0": {
-			// transaction details...
-		}
+			"3": {
+				// transaction details...
+			},
+			...
 		}
 	}
 */
@@ -290,13 +292,15 @@ Example response:
 	{
 		"pending": {
 			"0x12345": {
-				"0": "0x12345789: 1 wei + 2 gas x 3 wei"
-			}
+				"1": "0x12345789: 1 wei + 2 gas x 3 wei"
+			},
+			...
 		},
 		"queued": {
-			"0x12345": {
-				"0": "0x12345789: 1 wei + 2 gas x 3 wei"
-			}
+			"0x67890": {
+				"2": "0x12345789: 1 wei + 2 gas x 3 wei"
+			},
+			...
 		}
 	}
 */

--- a/core/transactor/event/dispatcher.go
+++ b/core/transactor/event/dispatcher.go
@@ -1,35 +1,29 @@
 package event
 
-// Dispatcher is a generic event dispatcher. It maintains a mapping of callers to subscribers,
-// which are channels that events are sent to.
+// Dispatcher is a generic event dispatcher. It maintains a mapping of unique indexes to
+// subscribers, which are channels that events are sent to.
 type Dispatcher[E any] struct {
-	subscribers []chan E
+	subscribers map[int]chan E
 }
 
 // NewDispatcher creates a new Dispatcher.
 func NewDispatcher[E any]() *Dispatcher[E] {
 	return &Dispatcher[E]{
-		subscribers: make([]chan E, 0),
+		subscribers: make(map[int]chan E),
 	}
 }
 
 // Subscribe adds a new subscriber to the Dispatcher. The subscriber is a channel on which events
-// will be sent to.
-func (d *Dispatcher[E]) Subscribe(subscriber chan E) {
-	d.subscribers = append(d.subscribers, subscriber)
+// will be sent to. Returns the unique index of the subscriber.
+func (d *Dispatcher[E]) Subscribe(subscriber chan E) int {
+	index := len(d.subscribers)
+	d.subscribers[index] = subscriber
+	return index
 }
 
-// Unsubscribe removes a subscriber from the Dispatcher. The subscriber is a channel that events
-// will no longer be sent to.
-// The for loop kinda hood, but in practice he length of `subscribers` is going to be so small it
-// doesn't really matter.
-func (d *Dispatcher[E]) Unsubscribe(subscriber chan E) {
-	for i, s := range d.subscribers {
-		if s == subscriber {
-			d.subscribers = append(d.subscribers[:i], d.subscribers[i+1:]...)
-			return
-		}
-	}
+// Unsubscribe removes a subscriber from the Dispatcher at the given unique index.
+func (d *Dispatcher[E]) Unsubscribe(index int) {
+	delete(d.subscribers, index)
 }
 
 // Dispatch sends an event to all subscribers.

--- a/core/transactor/loop.go
+++ b/core/transactor/loop.go
@@ -108,7 +108,7 @@ func (t *TxrV2) fire(
 		t.dispatcher.Dispatch(resp)
 		return
 	}
-	t.logger.Debug("📡 sent transaction", "hash", resp.Hash().Hex(), "reqs", len(resp.MsgIDs))
+	t.logger.Info("📡 sent transaction", "hash", resp.Hash().Hex(), "reqs", len(resp.MsgIDs))
 
 	// Call the tracker to track the transaction async.
 	t.markState(types.StateInFlight, resp.MsgIDs...)

--- a/core/transactor/loop.go
+++ b/core/transactor/loop.go
@@ -27,16 +27,10 @@ func (t *TxrV2) mainLoop(ctx context.Context) {
 			}
 
 			// We got a batch, so we can build and fire, after the previous fire has finished.
-			t.senderMu.Lock()
-			go func() {
-				defer t.senderMu.Unlock()
-
-				t.fire(
-					ctx,
-					&tracker.Response{MsgIDs: requests.MsgIDs(), InitialTimes: requests.Times()},
-					true, requests.Messages()...,
-				)
-			}()
+			go t.fire(
+				ctx, &tracker.Response{MsgIDs: requests.MsgIDs(), InitialTimes: requests.Times()},
+				true, requests.Messages()...,
+			)
 		}
 	}
 }
@@ -88,23 +82,22 @@ func (t *TxrV2) retrieveBatch(ctx context.Context) types.Requests {
 }
 
 // fire processes the tracked tx response. If requested to build, it will first batch the messages.
-// Then it sends the batch as one tx and asynchronously tracks the tx for its status.
-// NOTE: if toBuild is false, resp.Transaction must be a valid, signed tx.
+// Then it sends the batch as one tx and asynchronously tracks the tx for its status. Will return
+// early and notify tx subscribers if an error occurs during building or sending.
+// NOTE: if `toBuild` is false, resp.Transaction must be a valid, signed tx.
+// NOTE: this function blocks until any previous calls to `fire` are completed.
 func (t *TxrV2) fire(
 	ctx context.Context, resp *tracker.Response, toBuild bool, msgs ...*ethereum.CallMsg,
 ) {
-	defer func() {
-		// If there was an error in building or sending the tx, let the subscribers know.
-		if resp.Status() == tracker.StatusError {
-			t.dispatcher.Dispatch(resp)
-		}
-	}()
+	t.senderMu.Lock()
+	defer t.senderMu.Unlock()
 
 	if toBuild {
 		// Call the factory to build the (batched) transaction.
 		t.markState(types.StateBuilding, resp.MsgIDs...)
 		resp.Transaction, resp.Error = t.factory.BuildTransactionFromRequests(ctx, msgs...)
 		if resp.Error != nil {
+			t.dispatcher.Dispatch(resp)
 			return
 		}
 	}
@@ -112,6 +105,7 @@ func (t *TxrV2) fire(
 	// Call the sender to send the transaction to the chain.
 	t.markState(types.StateSending, resp.MsgIDs...)
 	if resp.Error = t.sender.SendTransaction(ctx, resp.Transaction); resp.Error != nil {
+		t.dispatcher.Dispatch(resp)
 		return
 	}
 	t.logger.Debug("📡 sent transaction", "hash", resp.Hash().Hex(), "reqs", len(resp.MsgIDs))

--- a/core/transactor/loop.go
+++ b/core/transactor/loop.go
@@ -18,7 +18,7 @@ func (t *TxrV2) mainLoop(ctx context.Context) {
 			return
 		default:
 			// Attempt the retrieve a batch from the queue.
-			requests := t.retrieveBatch(ctx)
+			requests := t.retrieveBatch()
 			if len(requests) == 0 {
 				// We didn't get any transactions, so we wait for more.
 				t.logger.Info("no tx requests to process....")
@@ -37,7 +37,7 @@ func (t *TxrV2) mainLoop(ctx context.Context) {
 
 // retrieveBatch retrieves a batch of transaction requests from the queue. It waits until 1) it
 // hits the batch timeout or 2) tx batch size is reached only if waitFullBatchTimeout is false.
-func (t *TxrV2) retrieveBatch(ctx context.Context) types.Requests {
+func (t *TxrV2) retrieveBatch() types.Requests {
 	var (
 		requests types.Requests
 		timer    = time.NewTimer(t.cfg.TxBatchTimeout)
@@ -47,8 +47,6 @@ func (t *TxrV2) retrieveBatch(ctx context.Context) types.Requests {
 	// Loop until the batch tx timeout expires.
 	for {
 		select {
-		case <-ctx.Done():
-			return nil
 		case <-timer.C:
 			return requests
 		default:
@@ -70,13 +68,15 @@ func (t *TxrV2) retrieveBatch(ctx context.Context) types.Requests {
 				continue
 			}
 
-			// Update the batched tx requests.
-			for i, txReq := range txReqs {
-				if t.cfg.UseQueueMessageID {
+			// If using the queue message ID, we need to update the message ID for each tx request.
+			if t.cfg.UseQueueMessageID {
+				for i, txReq := range txReqs {
 					txReq.MsgID = msgIDs[i]
 				}
-				requests = append(requests, txReq)
 			}
+
+			// Append the tx requests for retrieval.
+			requests = append(requests, txReqs...)
 		}
 	}
 }

--- a/core/transactor/tracker.go
+++ b/core/transactor/tracker.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/berachain/offchain-sdk/core/transactor/sender"
 	"github.com/berachain/offchain-sdk/core/transactor/tracker"
-	"github.com/berachain/offchain-sdk/core/transactor/types"
 
 	coretypes "github.com/ethereum/go-ethereum/core/types"
 )
@@ -54,7 +53,7 @@ func (t *TxrV2) OnSuccess(resp *tracker.Response, receipt *coretypes.Receipt) er
 // OnRevert is called when a transaction has been reverted.
 func (t *TxrV2) OnRevert(resp *tracker.Response, receipt *coretypes.Receipt) error {
 	t.removeStateTracking(resp.MsgIDs...)
-	t.logger.Error(
+	t.logger.Warn(
 		"🔻 transaction mined: reverted", "tx-hash", receipt.TxHash.Hex(),
 		"gas-used", receipt.GasUsed, "status", receipt.Status, "nonce", resp.Nonce(),
 	)
@@ -79,7 +78,7 @@ func (t *TxrV2) OnStale(ctx context.Context, resp *tracker.Response, isPending b
 	// Try resending the tx to the chain if pending or configured to do so. Rebuild it (same tx
 	// data, new nonce) and resend.
 	if isPending || t.cfg.ResendStaleTxs {
-		go t.fire(ctx, resp, false, types.CallMsgFromTx(resp.Transaction))
+		go t.fire(ctx, resp, false)
 	}
 
 	return nil

--- a/core/transactor/tracker.go
+++ b/core/transactor/tracker.go
@@ -11,17 +11,16 @@ import (
 )
 
 // OnError is called when a transaction request fails to build or send.
-func (t *TxrV2) OnError(_ context.Context, resp *tracker.Response) error {
+func (t *TxrV2) OnError(_ context.Context, resp *tracker.Response) {
 	t.noncer.RemoveAcquired(resp.Nonce())
 	t.removeStateTracking(resp.MsgIDs...)
 	t.logger.Error("❌ error sending transaction", "err", resp.Error, "msgs", resp.MsgIDs)
 
 	// TODO: move ontop dead queue, for SQS.
-	return nil
 }
 
 // OnSuccess is called when a transaction has been successfully included in a block.
-func (t *TxrV2) OnSuccess(resp *tracker.Response, receipt *coretypes.Receipt) error {
+func (t *TxrV2) OnSuccess(resp *tracker.Response, receipt *coretypes.Receipt) {
 	t.removeStateTracking(resp.MsgIDs...)
 	t.logger.Info(
 		"⛏️ transaction mined: success", "tx-hash", receipt.TxHash.Hex(),
@@ -47,11 +46,10 @@ func (t *TxrV2) OnSuccess(resp *tracker.Response, receipt *coretypes.Receipt) er
 		t.logger.Error("error deleting request from queue", "id", key, "err", value)
 		return true
 	})
-	return nil
 }
 
 // OnRevert is called when a transaction has been reverted.
-func (t *TxrV2) OnRevert(resp *tracker.Response, receipt *coretypes.Receipt) error {
+func (t *TxrV2) OnRevert(resp *tracker.Response, receipt *coretypes.Receipt) {
 	t.removeStateTracking(resp.MsgIDs...)
 	t.logger.Warn(
 		"🔻 transaction mined: reverted", "tx-hash", receipt.TxHash.Hex(),
@@ -59,11 +57,10 @@ func (t *TxrV2) OnRevert(resp *tracker.Response, receipt *coretypes.Receipt) err
 	)
 
 	// TODO: delete from SQS queue / move onto the dead queue?
-	return nil
 }
 
 // OnStale is called when a transaction becomes stale after the configured timeout.
-func (t *TxrV2) OnStale(ctx context.Context, resp *tracker.Response, isPending bool) error {
+func (t *TxrV2) OnStale(ctx context.Context, resp *tracker.Response, isPending bool) {
 	t.removeStateTracking(resp.MsgIDs...)
 	t.logger.Warn(
 		"🔄 transaction is stale", "tx-hash", resp.Hash(),
@@ -80,6 +77,4 @@ func (t *TxrV2) OnStale(ctx context.Context, resp *tracker.Response, isPending b
 	if isPending || t.cfg.ResendStaleTxs {
 		go t.fire(ctx, resp, false)
 	}
-
-	return nil
 }

--- a/core/transactor/tracker.go
+++ b/core/transactor/tracker.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/berachain/offchain-sdk/core/transactor/sender"
 	"github.com/berachain/offchain-sdk/core/transactor/tracker"
+	"github.com/berachain/offchain-sdk/core/transactor/types"
 
 	coretypes "github.com/ethereum/go-ethereum/core/types"
 )
@@ -67,14 +68,14 @@ func (t *TxrV2) OnStale(ctx context.Context, resp *tracker.Response, isPending b
 		"nonce", resp.Nonce(), "gas-price", resp.GasPrice(),
 	)
 
-	// For a pending tx "stuck" the mempool, it can only be included by bumping gas.
 	if isPending {
+		// For a tx that gets stuck in the mempool as pending, it can only be included in a block
+		// by bumping gas. Resend it (same tx data, same nonce) with a bumped gas.
 		resp.Transaction = sender.BumpGas(resp.Transaction)
-	}
-
-	// Try resending the tx to the chain if pending or configured to do so. Rebuild it (same tx
-	// data, new nonce) and resend.
-	if isPending || t.cfg.ResendStaleTxs {
 		go t.fire(ctx, resp, false)
+	} else if t.cfg.ResendStaleTxs {
+		// Try resending the tx to the chain if configured to do so. Rebuild it (same tx data, new
+		// nonce) and resend.
+		go t.fire(ctx, resp, true, types.CallMsgFromTx(resp.Transaction))
 	}
 }

--- a/core/transactor/tracker/response.go
+++ b/core/transactor/tracker/response.go
@@ -55,8 +55,7 @@ func (r *Response) To() *common.Address {
 		return r.Transaction.To()
 	}
 
-	zeroAddr := common.Address{}
-	return &zeroAddr
+	return &(common.Address{})
 }
 
 // Hash overrides the method on Transaction to avoid dereferencing a nil pointer.

--- a/core/transactor/tracker/subscription.go
+++ b/core/transactor/tracker/subscription.go
@@ -32,7 +32,7 @@ func NewSubscription(s Subscriber, logger log.Logger) *Subscription {
 
 // Start starts the Subscription, listening for transaction events.
 //
-//nolint:gocognit // okay.
+
 func (sub *Subscription) Start(ctx context.Context, ch chan *Response) {
 	// Loop over the channel, handling events as they come in.
 	for {

--- a/core/transactor/transactor.go
+++ b/core/transactor/transactor.go
@@ -99,9 +99,12 @@ func (t *TxrV2) Setup(ctx context.Context) error {
 	t.tracker.SetClient(chain)
 	t.noncer.Start(ctx, chain)
 
-	// If there are any pending txns at startup, they are likely to be "stuck". Resend them.
-	if err := t.resendStaleTxns(ctx, chain); err != nil {
-		return err
+	// If there are any pending txns at startup, they are likely to be "stuck". Resend them if
+	// configured to do so.
+	if t.cfg.ResendStaleTxs {
+		if err := t.resendStaleTxns(ctx, chain); err != nil {
+			return err
+		}
 	}
 
 	go t.mainLoop(ctx)
@@ -110,7 +113,7 @@ func (t *TxrV2) Setup(ctx context.Context) error {
 }
 
 // Execute implements job.Basic.
-func (t *TxrV2) Execute(_ context.Context, _ any) (any, error) {
+func (t *TxrV2) Execute(context.Context, any) (any, error) {
 	acquired, inFlight := t.noncer.Stats()
 	t.logger.Info(
 		"🧠 system status",

--- a/core/transactor/transactor.go
+++ b/core/transactor/transactor.go
@@ -212,12 +212,11 @@ func (t *TxrV2) resendStaleTxns(ctx context.Context, chain eth.Client) error {
 		return err
 	}
 
-	pendingTxs := txPoolContent["pending"]
-	if len(pendingTxs) > 0 {
-		t.logger.Info("resending stale transactions", "count", len(pendingTxs))
-	}
-	for _, tx := range pendingTxs {
-		t.fire(ctx, &tracker.Response{Transaction: sender.BumpGas(tx)}, false)
+	if pendingTxs := txPoolContent["pending"]; len(pendingTxs) > 0 {
+		t.logger.Info("🔄 resending stale transactions", "count", len(pendingTxs))
+		for _, tx := range pendingTxs {
+			t.fire(ctx, &tracker.Response{Transaction: sender.BumpGas(tx)}, false)
+		}
 	}
 
 	return nil

--- a/core/transactor/transactor.go
+++ b/core/transactor/transactor.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/berachain/offchain-sdk/client/eth"
 	"github.com/berachain/offchain-sdk/core/transactor/event"
 	"github.com/berachain/offchain-sdk/core/transactor/factory"
 	"github.com/berachain/offchain-sdk/core/transactor/sender"
@@ -90,13 +91,7 @@ func (t *TxrV2) Setup(ctx context.Context) error {
 	t.logger = sCtx.Logger()
 
 	// Register the transactor as a subscriber to the tracker.
-	ch := make(chan *tracker.Response)
-	go func() {
-		subCtx, cancel := context.WithCancel(ctx)
-		_ = tracker.NewSubscription(t, t.logger).Start(subCtx, ch) // TODO: handle error
-		cancel()
-	}()
-	t.dispatcher.Subscribe(ch)
+	t.SubscribeTxResults(ctx, t)
 
 	// Setup and start all the transactor components.
 	t.factory.SetClient(chain)
@@ -104,9 +99,8 @@ func (t *TxrV2) Setup(ctx context.Context) error {
 	t.tracker.SetClient(chain)
 	t.noncer.Start(ctx, chain)
 
-	// If there are any pending txns at startup, they are likely to be stuck in the mempool.
-	// Resend them.
-	if err := t.resendStaleTxns(ctx); err != nil {
+	// If there are any pending txns at startup, they are likely to be "stuck". Resend them.
+	if err := t.resendStaleTxns(ctx, chain); err != nil {
 		return err
 	}
 
@@ -163,13 +157,13 @@ func (t *TxrV2) SendTxRequest(txReq *types.Request) (string, error) {
 // ForceTxRequest immediately (whenever the sender is free from any previous sends) builds and
 // sends the tx request to the chain, after validating it.
 // NOTE: this bypasses the queue and batching even if configured to do so.
-func (t *TxrV2) ForceTxRequest(txReq *types.Request) (string, error) {
+func (t *TxrV2) ForceTxRequest(ctx context.Context, txReq *types.Request) (string, error) {
 	if err := txReq.Validate(); err != nil {
 		return "", err
 	}
 
 	go t.fire(
-		context.Background(),
+		ctx,
 		&tracker.Response{MsgIDs: []string{txReq.MsgID}, InitialTimes: []time.Time{txReq.Time()}},
 		true, txReq.CallMsg,
 	)
@@ -206,23 +200,22 @@ func (t *TxrV2) removeStateTracking(msgIDs ...string) {
 	}
 }
 
-// resendStaleTxns resends all the stale (pending) transactions in the tx pool.
-func (t *TxrV2) resendStaleTxns(ctx context.Context) error {
-	sCtx := sdk.UnwrapContext(ctx)
-	chain := sCtx.Chain()
-
-	content, err := chain.TxPoolContentFrom(ctx, t.signerAddr)
+// resendStaleTxns resends all the stale (pending) transactions in the mempool.
+// NOTE: blocks until resending all the pending txs either error and/or are sent to the chain.
+func (t *TxrV2) resendStaleTxns(ctx context.Context, chain eth.Client) error {
+	txPoolContent, err := chain.TxPoolContentFrom(ctx, t.signerAddr)
 	if err != nil {
-		t.logger.Error("failed to get tx pool content", "err", err)
+		t.logger.Error("failed to get tx pool content from", "err", err)
 		return err
 	}
 
-	for _, txn := range content["pending"] {
-		bumpedTxn := sender.BumpGas(txn)
-		if err = t.sender.SendTransaction(ctx, bumpedTxn); err != nil {
-			t.logger.Error("failed to resend stale transaction", "err", err)
-			return err
-		}
+	pendingTxs := txPoolContent["pending"]
+	if len(pendingTxs) > 0 {
+		t.logger.Info("resending stale transactions", "count", len(pendingTxs))
 	}
+	for _, tx := range pendingTxs {
+		t.fire(ctx, &tracker.Response{Transaction: sender.BumpGas(tx)}, false)
+	}
+
 	return nil
 }

--- a/core/transactor/transactor.go
+++ b/core/transactor/transactor.go
@@ -160,6 +160,21 @@ func (t *TxrV2) SendTxRequest(txReq *types.Request) (string, error) {
 	return msgID, nil
 }
 
+// ForceTxRequest immediately (whenever the sender is free from any previous sends) builds and
+// sends the tx request to the chain, after validating it.
+func (t *TxrV2) ForceTxRequest(txReq *types.Request) (string, error) {
+	if err := txReq.Validate(); err != nil {
+		return "", err
+	}
+
+	go t.fire(
+		context.Background(),
+		&tracker.Response{MsgIDs: []string{txReq.MsgID}, InitialTimes: []time.Time{txReq.Time()}},
+		true, txReq.CallMsg,
+	)
+	return txReq.MsgID, nil
+}
+
 // GetPreconfirmedState returns the status of the given message ID before it has been confirmed by
 // the chain.
 func (t *TxrV2) GetPreconfirmedState(msgID string) types.PreconfirmedState {

--- a/core/transactor/transactor.go
+++ b/core/transactor/transactor.go
@@ -162,6 +162,7 @@ func (t *TxrV2) SendTxRequest(txReq *types.Request) (string, error) {
 
 // ForceTxRequest immediately (whenever the sender is free from any previous sends) builds and
 // sends the tx request to the chain, after validating it.
+// NOTE: this bypasses the queue and batching even if configured to do so.
 func (t *TxrV2) ForceTxRequest(txReq *types.Request) (string, error) {
 	if err := txReq.Validate(); err != nil {
 		return "", err


### PR DESCRIPTION
Also concurrency fix: enforces sender locking when firing any transactions