### PR TITLE
feat(jobs): Add stale timeout check to subscription jobs

### DIFF
--- a/baseapp/job_manager.go
+++ b/baseapp/job_manager.go
@@ -12,6 +12,8 @@ import (
 	"github.com/berachain/offchain-sdk/worker"
 )
 
+// REMOVE: Tag issue #93
+
 const (
 	producerName           = "job-producer"
 	producerPromName       = "job_producer"

--- a/baseapp/job_manager.go
+++ b/baseapp/job_manager.go
@@ -12,8 +12,6 @@ import (
 	"github.com/berachain/offchain-sdk/worker"
 )
 
-// REMOVE: Tag issue #93
-
 const (
 	producerName           = "job-producer"
 	producerPromName       = "job_producer"

--- a/baseapp/job_manager.go
+++ b/baseapp/job_manager.go
@@ -152,9 +152,9 @@ func (jm *JobManager) RunProducers(gctx context.Context) {
 			jm.jobProducers.Submit(jm.producerTask(ctx, wrappedJob))
 		} else if subJob, ok := j.(job.Subscribable); ok {
 			jm.jobProducers.Submit(jm.withRetry(jm.retryableSubscriber(ctx, subJob)))
-		} else if ethSubJob, ok := j.(job.EthSubscribable); ok {
+		} else if ethSubJob, ok := j.(job.EthSubscribable); ok { //nolint:govet // todo fix.
 			jm.jobProducers.Submit(jm.withRetry(jm.retryableEthSubscriber(ctx, ethSubJob)))
-		} else if blockHeaderJob, ok := j.(job.BlockHeaderSub); ok {
+		} else if blockHeaderJob, ok := j.(job.BlockHeaderSub); ok { //nolint:govet // todo fix.
 			jm.jobProducers.Submit(jm.withRetry(jm.retryableHeaderSubscriber(ctx, blockHeaderJob)))
 		} else {
 			panic(fmt.Sprintf("unknown job type %s", reflect.TypeOf(j)))

--- a/baseapp/job_manager.go
+++ b/baseapp/job_manager.go
@@ -39,6 +39,8 @@ type JobManager struct {
 	// are fed jobs by the job producers.
 	executorCfg  *worker.PoolConfig
 	jobExecutors *worker.Pool
+
+	// TODO: introduce telemetry.Metrics to this struct and the BaseApp.
 }
 
 // NewManager creates a new manager.

--- a/baseapp/retry.go
+++ b/baseapp/retry.go
@@ -1,0 +1,43 @@
+package baseapp
+
+import (
+	"crypto/rand"
+	"math/big"
+	"time"
+)
+
+// Retry parameters.
+const (
+	maxBackoff               = 2 * time.Minute
+	backoffStart             = 1 * time.Second
+	backoffBase              = 2
+	jitterRange              = 1000
+	subscriptionStaleTimeout = 1 * time.Hour
+)
+
+// withRetry is a wrapper that retries a task with exponential backoff.
+func (jm *JobManager) withRetry(task func() bool) func() {
+	return func() {
+		backoff := backoffStart
+
+		for {
+			shouldRetry := task()
+			if !shouldRetry {
+				return
+			}
+
+			// Exponential backoff with jitter.
+			jitter, _ := rand.Int(rand.Reader, big.NewInt(jitterRange))
+			if jitter == nil {
+				jitter = new(big.Int)
+			}
+			sleep := backoff + time.Duration(jitter.Int64())*time.Millisecond
+			time.Sleep(sleep)
+
+			backoff *= backoffBase
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+		}
+	}
+}

--- a/baseapp/runners.go
+++ b/baseapp/runners.go
@@ -1,0 +1,142 @@
+package baseapp
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/berachain/offchain-sdk/job"
+	workertypes "github.com/berachain/offchain-sdk/job/types"
+)
+
+// producerTask returns a execution task for the given HasProducer job.
+func (jm *JobManager) producerTask(ctx context.Context, wrappedJob job.HasProducer) func() {
+	return func() {
+		err := wrappedJob.Producer(ctx, jm.jobExecutors)
+		if err != nil && !errors.Is(err, context.Canceled) {
+			jm.Logger(ctx).Error(
+				"error in job producer", "job", wrappedJob.RegistryKey(), "err", err,
+			)
+		}
+	}
+}
+
+// retryableSubscriber returns a retryable, execution task for the given Subscribable job.
+func (jm *JobManager) retryableSubscriber(ctx context.Context, subJob job.Subscribable) func() bool {
+	return func() bool {
+		ch := subJob.Subscribe(ctx)
+		jm.Logger(ctx).Info("(re)subscribed to subscription", "job", subJob.RegistryKey())
+
+		// Ensure that the subscription does not drop due to no messages received.
+		staleSubscription := time.NewTimer(subscriptionStaleTimeout)
+		defer staleSubscription.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return false // no need to retry
+			case staleTime := <-staleSubscription.C:
+				jm.Logger(ctx).Warn(
+					"subscription went stale, reconnecting...",
+					"time", staleTime, "job", subJob.RegistryKey(),
+				)
+				return true // should retry again
+			case val := <-ch:
+				jm.jobExecutors.Submit(workertypes.NewPayload(ctx, subJob, val).Execute)
+				staleSubscription.Reset(subscriptionStaleTimeout)
+			}
+		}
+	}
+}
+
+// retryableEthSubscriber returns a retryable, execution task for the given EthSubscribable job.
+func (jm *JobManager) retryableEthSubscriber(
+	ctx context.Context, ethSubJob job.EthSubscribable,
+) func() bool {
+	return func() bool {
+		sub, ch, err := ethSubJob.Subscribe(ctx)
+		if err != nil {
+			jm.Logger(ctx).Error(
+				"error subscribing to filter logs, retrying...",
+				"job", ethSubJob.RegistryKey(), "err", err,
+			)
+			return true // should retry again
+		}
+		jm.Logger(ctx).Info("(re)subscribed to eth subscription", "job", ethSubJob.RegistryKey())
+
+		// Ensure that the subscription does not drop due to no messages received.
+		staleSubscription := time.NewTimer(subscriptionStaleTimeout)
+		defer staleSubscription.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				ethSubJob.Unsubscribe(ctx)
+				return false // no need to retry
+			case err = <-sub.Err():
+				jm.Logger(ctx).Error(
+					"error in subscription, retrying...",
+					"job", ethSubJob.RegistryKey(), "err", err,
+				)
+				ethSubJob.Unsubscribe(ctx)
+				return true // should retry again
+			case staleTime := <-staleSubscription.C:
+				jm.Logger(ctx).Warn(
+					"subscription went stale, reconnecting...",
+					"time", staleTime, "job", ethSubJob.RegistryKey(),
+				)
+				return true // should retry again
+			case val := <-ch:
+				jm.jobExecutors.Submit(workertypes.NewPayload(ctx, ethSubJob, val).Execute)
+				staleSubscription.Reset(subscriptionStaleTimeout)
+			}
+		}
+	}
+}
+
+// retryableEthSubscriber returns a retryable, execution task for the given BlockHeaderSub job.
+func (jm *JobManager) retryableHeaderSubscriber(
+	ctx context.Context, blockHeaderJob job.BlockHeaderSub,
+) func() bool {
+	return func() bool {
+		sub, ch, err := blockHeaderJob.Subscribe(ctx)
+		if err != nil {
+			jm.Logger(ctx).Error(
+				"error subscribing block header",
+				"job", blockHeaderJob.RegistryKey(), "err", err,
+			)
+			return true // should retry again
+		}
+		jm.Logger(ctx).Info(
+			"(re)subscribed to block header sub", "job", blockHeaderJob.RegistryKey(),
+		)
+
+		// Ensure that the subscription does not drop due to no messages received.
+		staleSubscription := time.NewTimer(subscriptionStaleTimeout)
+		defer staleSubscription.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				blockHeaderJob.Unsubscribe(ctx)
+				return false // no need to retry
+			case err = <-sub.Err():
+				jm.Logger(ctx).Error(
+					"error in subscription, retrying...",
+					"job", blockHeaderJob.RegistryKey(), "err", err,
+				)
+				blockHeaderJob.Unsubscribe(ctx)
+				return true // should retry again
+			case staleTime := <-staleSubscription.C:
+				jm.Logger(ctx).Warn(
+					"subscription went stale, reconnecting...",
+					"time", staleTime, "job", blockHeaderJob.RegistryKey(),
+				)
+				return true // should retry again
+			case val := <-ch:
+				jm.jobExecutors.Submit(workertypes.NewPayload(ctx, blockHeaderJob, val).Execute)
+				staleSubscription.Reset(subscriptionStaleTimeout)
+			}
+		}
+	}
+}

--- a/baseapp/runners.go
+++ b/baseapp/runners.go
@@ -51,6 +51,10 @@ func (jm *JobManager) retryableSubscriber(
 }
 
 // retryableEthSubscriber returns a retryable, execution task for the given EthSubscribable job.
+//
+// TODO: cleanup the job types interfaces to avoid overlap using generics.
+//
+//nolint:dupl // refer to TODO above.
 func (jm *JobManager) retryableEthSubscriber(
 	ctx context.Context, ethSubJob job.EthSubscribable,
 ) func() bool {
@@ -95,6 +99,10 @@ func (jm *JobManager) retryableEthSubscriber(
 }
 
 // retryableEthSubscriber returns a retryable, execution task for the given BlockHeaderSub job.
+//
+// TODO: cleanup the job types interfaces to avoid overlap using generics.
+//
+//nolint:dupl // refer to TODO above.
 func (jm *JobManager) retryableHeaderSubscriber(
 	ctx context.Context, blockHeaderJob job.BlockHeaderSub,
 ) func() bool {


### PR DESCRIPTION
Necessary for jobs that subscribe to eth RPC WS using `eth_subscribe{}` since there is no ability to send health message on the subscription with the geth RPC client

Closes #93 