### PR TITLE
chore (telemetry) Fix the naming of Latency Metrics

### DIFF
--- a/telemetry/prometheus/metrics.go
+++ b/telemetry/prometheus/metrics.go
@@ -208,7 +208,7 @@ func (p *metrics) Time(name string, value time.Duration, tags []string) {
 
 // Latency is a helper function to measure the latency of a routine.
 func (p *metrics) Latency(jobName string, start time.Time, tags ...string) {
-	p.Time("stats.latency", time.Since(start), append(tags, fmt.Sprintf("job:%s", jobName)))
+	p.Time(fmt.Sprintf("%s.latency", jobName), time.Since(start), tags)
 }
 
 // parseTagsToLabelPairs converts a slice of tags in "key:value" format to two slices:

--- a/telemetry/prometheus/metrics.go
+++ b/telemetry/prometheus/metrics.go
@@ -155,7 +155,7 @@ func (p *metrics) IncMonotonic(name string, tags []string) {
 
 // Error implements the Error method of the Metrics interface using CounterVec.
 func (p *metrics) Error(errName string) {
-	p.IncMonotonic("stats.errors", []string{fmt.Sprintf("type:%s", errName)})
+	p.IncMonotonic("errors", []string{fmt.Sprintf("type:%s", errName)})
 }
 
 // Histogram implements the Histogram method of the Metrics interface using HistogramVec.


### PR DESCRIPTION
Using different name for `Latency` metrics, to avoid coupling of multiple clients using `Latency` metrics with same naming