### PR TITLE
feat (Telemetry) Use Summary to record percentile metrics of time

### DIFF
--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -26,8 +26,8 @@ emitted from Datadog.
 ### Datadog Methods
 
 [metrics.go](./datadog/metrics.go) implements the Datadog version of the supported metrics methods
-defined in [type.go](./type.go). All implementations are simple wrappers around the native methods
-in Datadog.
+defined in [types.go](./types.go). All implementations are simple wrappers around the native methods
+provided by the Datadog `statsd` client.
 
 ## Prometheus
 

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -23,13 +23,15 @@ emitted from Datadog
 
 ### Datadog Methods
 
-`./datadog/metrics.go` impelements the Datadog version of the supported metrics method defined in
+`./datadog/metrics.go` impelements the Datadog version of the supported metrics methods defined in
 `./type.go`. All implementation are just simple wrapper, wrapping the native methods in Datadog
 
 ## Prometheus
 
 The first step is adding a section in your config file. See following subsection for details. The
 source code defining those configs can be found in `./prometheus/config.go`
+
+### Prometheus Configs
 
 `Enabled`: change this to `true` if the metrics should be emitted to Prometheus
 
@@ -38,3 +40,26 @@ if `Namespace` is `app` and `Subsystem` is `api`, then the full metrics name of 
 will be `app_api_request_success`
 
 `HistogramBucketCount`: This is the count of buckets used for Histogram typed metrics. It is defaulted to 10.
+
+### Prometheus Methods
+
+Different from Datadog, Prometheus only provides
+[4 basic metrics type](https://prometheus.io/docs/concepts/metric_types/). As a result,
+`./prometheus/metrics.go` implements the metrics methods defined in `./type.go` using the 4 basic
+Prometheus metrics. Following subsection documents the methods that with implementation notes. For
+more information of the 4 basic Prometheus metrics, please see
+[here](https://prometheus.io/docs/tutorials/understanding_metric_types/).
+
+`Gauge`: this method wraps the `Gauge` metrics of Prometheus
+
+`Decr` and `Incr`: those 2 methods are implemented using the `Gauge` metrics of Prometheus
+
+`Count`: this method wraps the `Count` metrics of Prometheus. Please note that after deployment
+or restart of instance, `Count` will be reset to 0. This is a by-design feature of Prometheus
+
+`IncMonotonic` and `Error`: those 2 methods are implemented using the `Count` metrics of Prometheus
+
+`Histogram`: this method wraps the `Histogram` metrics of Prometheus with linear bucket
+
+`Time` and `Latency`: those 2 methods are implemented using the `Summary` metrics of Prometheus,
+using a pre-defined observation of quantile: p50, p90 and p99

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -2,29 +2,32 @@
 
 The metrics utility for offchain-sdk.
 
-`./type.go` defines the interface for the supported metrics methods.
+[type.go](./type.go`) defines the interface for the supported metrics methods.
 
-By specifying the config, the metrics can be emitted via Datadog and/or Prometheus. Please see
-following subsections for detailed configurations
+By specifying the configuration, the metrics can be emitted via Datadog and/or Prometheus.
+Please see the following subsections for detailed configurations.
 
 ## Datadog
+
+### Configuration
 
 The first step is adding a section in your config file. See following subsection for details. The
 source code defining those configs can be found in `./datadog/config.go`
 
-### Datadog Configs
+#### Datadog Configs
 
-`Enabled`: change this to `true` if the metrics should be emitted to Datadog
+`Enabled`: Set to `true` to enable metrics emission to Datadog.
 
-`StatsdAddr`: this is the address of Datadog Statsd client. This is needed if the metrics should be
-emitted from Datadog
+`StatsdAddr`: The address of the Datadog StatsD client. This is needed if the metrics should be
+emitted from Datadog.
 
-`Namespace`: this will appear as the tag `Namespace` in Datadog
+`Namespace`: This will appear as the `Namespace` tag in Datadog.
 
 ### Datadog Methods
 
-`./datadog/metrics.go` impelements the Datadog version of the supported metrics methods defined in
-`./type.go`. All implementation are just simple wrapper, wrapping the native methods in Datadog
+[metrics.go](./datadog/metrics.go) implements the Datadog version of the supported metrics methods
+defined in [type.go](./type.go). All implementations are simple wrappers around the native methods
+in Datadog.
 
 ## Prometheus
 

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,0 +1,35 @@
+# telemetry
+
+The metrics utility for offchain-sdk.
+
+`./type.go` defines the interface for the supported metrics methods.
+
+By specifying the config, the metrics can be emitted via Datadog and/or Prometheus. Please see
+following subsections for detailed configurations
+
+## Datadog
+
+The first step is adding a section in your config file. See following subsection for details. The
+source code defining those configs can be found in `./datadog/config.go`
+
+### Datadog Configs
+
+`Enabled`: change this to `true` if the metrics should be emitted to Datadog
+`StatsdAddr`: this is the address of Datadog Statsd client. This is needed if the metrics should be
+emitted from Datadog
+`Namespace`: this will appear as the tag `Namespace` in Datadog
+
+### Datadog Methods
+
+`./datadog/metrics.go` impelements the Datadog version of the supported metrics method defined in
+`./type.go`. All implementation are just simple wrapper, wrapping the native methods in Datadog
+
+## Prometheus
+
+The first step is adding a section in your config file. See following subsection for details. The
+source code defining those configs can be found in `./prometheus/config.go`
+`Enabled`: change this to `true` if the metrics should be emitted to Prometheus
+`Namespace` and `Subsystem`: those 2 fields will be added as prefix of metrics name. For example
+if `Namespace` is `app` and `Subsystem` is `api`, then the full metrics name of `request_success`
+will be `app_api_request_success`
+`HistogramBucketCount`: This is the count of buckets used for Histogram typed metrics. It is defaulted to 10.

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -34,7 +34,7 @@ provided by the Datadog `statsd` client.
 ### Configuration
 
 The first step is to add a section in your config file. The source code defining these configs can
-be found in  [config.go](./prometheus/config.go).
+be found in [config.go](./prometheus/config.go).
 
 #### Prometheus Configs
 

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -45,8 +45,8 @@ For example, if `Namespace` is `app` and `Subsystem` is `api`, then the full met
 `request_success` will be `app_api_request_success`.
 
 * `HistogramBucketCount`: The number of buckets used for Histogram typed metrics. Default is 10.
-  * Note: Each bucket is an observation that needs to scrape in Prometheus, thus the recommended
-    bucket count should be of scale of tens.
+  * Note: Each bucket represents an observation that Prometheus scrapes. Therefore, it's recommended
+    to keep the number of buckets within a manageable scale, typically in the tens.
 
 ### Prometheus Methods
 
@@ -67,8 +67,9 @@ restart, `Count` will reset to 0. This is by design in Prometheus.
 * `IncMonotonic` and `Error`: Implemented using the `Count` metrics of Prometheus.
 
 * `Histogram`: This method wraps the `Histogram` metrics of Prometheus with linear buckets.
-  * Note: the maximum covered value is BucketCount * rate, where rate is passed as a parameter.
-  * TODO: In addition to linear bucket, support different types of buckets in future
+  * Note: The maximum value covered is determined by the product of BucketCount and the rate
+    parameter.
+  * TODO: Support different types of buckets beyond linear buckets in future implementations.
 
 * `Time` and `Latency`: Implemented using the `Summary` metrics of Prometheus, with pre-defined
 quantile observations: p50, p90, and p99.

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -16,12 +16,12 @@ source code defining those configs can be found in [config.go](./datadog/config.
 
 #### Datadog Configs
 
-`Enabled`: Set to `true` to enable metrics emission to Datadog.
+* `Enabled`: Set to `true` to enable metrics emission to Datadog.
 
-`StatsdAddr`: The address of the Datadog StatsD client. This is needed if the metrics should be
+* `StatsdAddr`: The address of the Datadog StatsD client. This is needed if the metrics should be
 emitted from Datadog.
 
-`Namespace`: This will appear as the `Namespace` tag in Datadog.
+* `Namespace`: This will appear as the `Namespace` tag in Datadog.
 
 ### Datadog Methods
 
@@ -38,13 +38,13 @@ be found in  [config.go](./prometheus/config.go).
 
 #### Prometheus Configs
 
-`Enabled`: Set to true to enable metrics emission to Prometheus.
+* `Enabled`: Set to true to enable metrics emission to Prometheus.
 
-`Namespace` and `Subsystem`: These fields will be added as prefixes to the metrics name.
+* `Namespace` and `Subsystem`: These fields will be added as prefixes to the metrics name.
 For example, if `Namespace` is `app` and `Subsystem` is `api`, then the full metrics name of
 `request_success` will be `app_api_request_success`.
 
-`HistogramBucketCount`: The number of buckets used for Histogram typed metrics. Default is 10.
+* `HistogramBucketCount`: The number of buckets used for Histogram typed metrics. Default is 10.
 
 ### Prometheus Methods
 
@@ -55,16 +55,16 @@ using these four basic Prometheus metrics. The following subsection documents th
 implementation notes. For more information on the four basic Prometheus metrics, please see
 [here](https://prometheus.io/docs/tutorials/understanding_metric_types/).
 
-`Gauge`: This method wraps the `Gauge` metrics of Prometheus.
+* `Gauge`: This method wraps the `Gauge` metrics of Prometheus.
 
-`Decr` and `Incr`: Implemented using the `Gauge` metrics of Prometheus.
+* `Decr` and `Incr`: Implemented using the `Gauge` metrics of Prometheus.
 
-`Count`: This method wraps the `Count` metrics of Prometheus. Note that after deployment or instance
+* `Count`: This method wraps the `Count` metrics of Prometheus. Note that after deployment or instance
 restart, `Count` will reset to 0. This is by design in Prometheus.
 
-`IncMonotonic` and `Error`: Implemented using the `Count` metrics of Prometheus.
+* `IncMonotonic` and `Error`: Implemented using the `Count` metrics of Prometheus.
 
-`Histogram`: This method wraps the `Histogram` metrics of Prometheus with linear buckets.
+* `Histogram`: This method wraps the `Histogram` metrics of Prometheus with linear buckets.
 
-`Time` and `Latency`: Implemented using the `Summary` metrics of Prometheus, with pre-defined
+* `Time` and `Latency`: Implemented using the `Summary` metrics of Prometheus, with pre-defined
 quantile observations: p50, p90, and p99.

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -2,7 +2,7 @@
 
 The metrics utility for offchain-sdk.
 
-[type.go](./type.go`) defines the interface for the supported metrics methods.
+[type.go](./type.go) defines the interface for the supported metrics methods.
 
 By specifying the configuration, the metrics can be emitted via Datadog and/or Prometheus.
 Please see the following subsections for detailed configurations.
@@ -12,7 +12,7 @@ Please see the following subsections for detailed configurations.
 ### Configuration
 
 The first step is adding a section in your config file. See following subsection for details. The
-source code defining those configs can be found in `./datadog/config.go`
+source code defining those configs can be found in [config.go](./datadog/config.go).
 
 #### Datadog Configs
 
@@ -31,38 +31,40 @@ in Datadog.
 
 ## Prometheus
 
-The first step is adding a section in your config file. See following subsection for details. The
-source code defining those configs can be found in `./prometheus/config.go`
+### Configuration
 
-### Prometheus Configs
+The first step is to add a section in your config file. The source code defining these configs can
+be found in  [config.go](./prometheus/config.go).
 
-`Enabled`: change this to `true` if the metrics should be emitted to Prometheus
+#### Prometheus Configs
 
-`Namespace` and `Subsystem`: those 2 fields will be added as prefix of metrics name. For example
-if `Namespace` is `app` and `Subsystem` is `api`, then the full metrics name of `request_success`
-will be `app_api_request_success`
+`Enabled`: Set to true to enable metrics emission to Prometheus.
 
-`HistogramBucketCount`: This is the count of buckets used for Histogram typed metrics. It is defaulted to 10.
+`Namespace` and `Subsystem`: These fields will be added as prefixes to the metrics name.
+For example, if `Namespace` is `app` and `Subsystem` is `api`, then the full metrics name of
+`request_success` will be `app_api_request_success`.
+
+`HistogramBucketCount`: The number of buckets used for Histogram typed metrics. Default is 10.
 
 ### Prometheus Methods
 
 Different from Datadog, Prometheus only provides
 [4 basic metrics type](https://prometheus.io/docs/concepts/metric_types/). As a result,
-`./prometheus/metrics.go` implements the metrics methods defined in `./type.go` using the 4 basic
-Prometheus metrics. Following subsection documents the methods that with implementation notes. For
-more information of the 4 basic Prometheus metrics, please see
+[metrics.go](./prometheus/metrics.go) implements the metrics methods defined in [type.go](./type.go)
+using these four basic Prometheus metrics. The following subsection documents the methods with
+implementation notes. For more information on the four basic Prometheus metrics, please see
 [here](https://prometheus.io/docs/tutorials/understanding_metric_types/).
 
-`Gauge`: this method wraps the `Gauge` metrics of Prometheus
+`Gauge`: This method wraps the `Gauge` metrics of Prometheus.
 
-`Decr` and `Incr`: those 2 methods are implemented using the `Gauge` metrics of Prometheus
+`Decr` and `Incr`: Implemented using the `Gauge` metrics of Prometheus.
 
-`Count`: this method wraps the `Count` metrics of Prometheus. Please note that after deployment
-or restart of instance, `Count` will be reset to 0. This is a by-design feature of Prometheus
+`Count`: This method wraps the `Count` metrics of Prometheus. Note that after deployment or instance
+restart, `Count` will reset to 0. This is by design in Prometheus.
 
-`IncMonotonic` and `Error`: those 2 methods are implemented using the `Count` metrics of Prometheus
+`IncMonotonic` and `Error`: Implemented using the `Count` metrics of Prometheus.
 
-`Histogram`: this method wraps the `Histogram` metrics of Prometheus with linear bucket
+`Histogram`: This method wraps the `Histogram` metrics of Prometheus with linear buckets.
 
-`Time` and `Latency`: those 2 methods are implemented using the `Summary` metrics of Prometheus,
-using a pre-defined observation of quantile: p50, p90 and p99
+`Time` and `Latency`: Implemented using the `Summary` metrics of Prometheus, with pre-defined
+quantile observations: p50, p90, and p99.

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -45,6 +45,8 @@ For example, if `Namespace` is `app` and `Subsystem` is `api`, then the full met
 `request_success` will be `app_api_request_success`.
 
 * `HistogramBucketCount`: The number of buckets used for Histogram typed metrics. Default is 10.
+  * Note: Each bucket is an observation that needs to scrape in Prometheus, thus the recommended
+    bucket count should be of scale of tens.
 
 ### Prometheus Methods
 
@@ -65,6 +67,8 @@ restart, `Count` will reset to 0. This is by design in Prometheus.
 * `IncMonotonic` and `Error`: Implemented using the `Count` metrics of Prometheus.
 
 * `Histogram`: This method wraps the `Histogram` metrics of Prometheus with linear buckets.
+  * Note: the maximum covered value is BucketCount * rate, where rate is passed as a parameter.
+  * TODO: In addition to linear bucket, support different types of buckets in future
 
 * `Time` and `Latency`: Implemented using the `Summary` metrics of Prometheus, with pre-defined
 quantile observations: p50, p90, and p99.

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -15,8 +15,10 @@ source code defining those configs can be found in `./datadog/config.go`
 ### Datadog Configs
 
 `Enabled`: change this to `true` if the metrics should be emitted to Datadog
+
 `StatsdAddr`: this is the address of Datadog Statsd client. This is needed if the metrics should be
 emitted from Datadog
+
 `Namespace`: this will appear as the tag `Namespace` in Datadog
 
 ### Datadog Methods
@@ -28,8 +30,11 @@ emitted from Datadog
 
 The first step is adding a section in your config file. See following subsection for details. The
 source code defining those configs can be found in `./prometheus/config.go`
+
 `Enabled`: change this to `true` if the metrics should be emitted to Prometheus
+
 `Namespace` and `Subsystem`: those 2 fields will be added as prefix of metrics name. For example
 if `Namespace` is `app` and `Subsystem` is `api`, then the full metrics name of `request_success`
 will be `app_api_request_success`
+
 `HistogramBucketCount`: This is the count of buckets used for Histogram typed metrics. It is defaulted to 10.

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -1,8 +1,8 @@
-# telemetry
+# Telemetry
 
 The metrics utility for offchain-sdk.
 
-[type.go](./type.go) defines the interface for the supported metrics methods.
+[types.go](./types.go) defines the interface for the supported metrics methods.
 
 By specifying the configuration, the metrics can be emitted via Datadog and/or Prometheus.
 Please see the following subsections for detailed configurations.

--- a/telemetry/datadog/metrics.go
+++ b/telemetry/datadog/metrics.go
@@ -38,7 +38,7 @@ func (m *metrics) Close() error {
 	return m.client.Close()
 }
 
-func (m *metrics) Gauge(name string, value float64, tags []string, rate float64) {
+func (m *metrics) Gauge(name string, value float64, rate float64, tags ...string) {
 	if !m.enabled {
 		return
 	}
@@ -46,7 +46,7 @@ func (m *metrics) Gauge(name string, value float64, tags []string, rate float64)
 	m.client.Gauge(name, value, tags, rate) //nolint:errcheck // handled by m.client.Gauge()
 }
 
-func (m *metrics) Count(name string, value int64, tags []string) {
+func (m *metrics) Count(name string, value int64, tags ...string) {
 	if !m.enabled {
 		return
 	}
@@ -54,11 +54,11 @@ func (m *metrics) Count(name string, value int64, tags []string) {
 	m.client.Count(name, value, tags, 1) //nolint:errcheck // handled by m.client.Count()
 }
 
-func (m *metrics) IncMonotonic(name string, tags []string) {
-	m.Incr(name, tags)
+func (m *metrics) IncMonotonic(name string, tags ...string) {
+	m.Incr(name, tags...)
 }
 
-func (m *metrics) Incr(name string, tags []string) {
+func (m *metrics) Incr(name string, tags ...string) {
 	if !m.enabled {
 		return
 	}
@@ -66,7 +66,7 @@ func (m *metrics) Incr(name string, tags []string) {
 	m.client.Incr(name, tags, 1) //nolint:errcheck // handled by m.client.Incr()
 }
 
-func (m *metrics) Decr(name string, tags []string) {
+func (m *metrics) Decr(name string, tags ...string) {
 	if !m.enabled {
 		return
 	}
@@ -74,7 +74,7 @@ func (m *metrics) Decr(name string, tags []string) {
 	m.client.Decr(name, tags, 1) //nolint:errcheck // handled by m.client.Decr()
 }
 
-func (m *metrics) Set(name string, value string, tags []string) {
+func (m *metrics) Set(name string, value string, tags ...string) {
 	if !m.enabled {
 		return
 	}
@@ -82,7 +82,7 @@ func (m *metrics) Set(name string, value string, tags []string) {
 	m.client.Set(name, value, tags, 1) //nolint:errcheck // handled by m.client.Set()
 }
 
-func (m *metrics) Histogram(name string, value float64, tags []string, rate float64) {
+func (m *metrics) Histogram(name string, value float64, rate float64, tags ...string) {
 	if !m.enabled {
 		return
 	}
@@ -90,7 +90,7 @@ func (m *metrics) Histogram(name string, value float64, tags []string, rate floa
 	m.client.Histogram(name, value, tags, rate) //nolint:errcheck // handled by m.client.Histogram()
 }
 
-func (m *metrics) Time(name string, value time.Duration, tags []string) {
+func (m *metrics) Time(name string, value time.Duration, tags ...string) {
 	if !m.enabled {
 		return
 	}
@@ -99,10 +99,10 @@ func (m *metrics) Time(name string, value time.Duration, tags []string) {
 }
 
 func (m *metrics) Error(errName string) {
-	m.Incr("stats.errors", []string{fmt.Sprintf("type:%s", errName)})
+	m.Incr("stats.errors", fmt.Sprintf("type:%s", errName))
 }
 
 // Latency is a helper function to measure the latency of a routine.
 func (m *metrics) Latency(jobName string, start time.Time, tags ...string) {
-	m.Time("stats.latency", time.Since(start), append(tags, fmt.Sprintf("job:%s", jobName)))
+	m.Time("stats.latency", time.Since(start), append(tags, fmt.Sprintf("job:%s", jobName))...)
 }

--- a/telemetry/handler_wrapper.go
+++ b/telemetry/handler_wrapper.go
@@ -39,13 +39,13 @@ func WrapHTTPHandler(m Metrics, log log.Logger) func(http.Handler) http.Handler 
 			metricsTags := getHTTPRequestTags(r)
 
 			// Increment request count metric under `request.count`
-			m.IncMonotonic("request.count", metricsTags)
+			m.IncMonotonic("request.count", metricsTags...)
 
 			start := time.Now()
 			next.ServeHTTP(customWriter, r)
 
 			// Record latency metric under `response.latency`
-			m.Time("request.latency", time.Since(start), metricsTags)
+			m.Time("request.latency", time.Since(start), metricsTags...)
 
 			// Separately record errors under `request.errors`
 			if customWriter.statusCode >= http.StatusBadRequest {
@@ -59,7 +59,7 @@ func WrapHTTPHandler(m Metrics, log log.Logger) func(http.Handler) http.Handler 
 				}
 
 				metricsTags = append(metricsTags, fmt.Sprintf("code:%d", customWriter.statusCode))
-				m.IncMonotonic("request.errors", metricsTags)
+				m.IncMonotonic("request.errors", metricsTags...)
 			}
 		})
 	}
@@ -73,13 +73,13 @@ func WrapMicroServerHandler(m Metrics, log log.Logger) server.HandlerWrapper {
 			metricsTags := getMicroRequestTags(req)
 
 			// Increment request count metric under `request.count`
-			m.IncMonotonic("request.count", metricsTags)
+			m.IncMonotonic("request.count", metricsTags...)
 
 			start := time.Now()
 			err := next(c, req, rsp)
 
 			// Record latency metric under `response.latency`
-			m.Time("request.latency", time.Since(start), metricsTags)
+			m.Time("request.latency", time.Since(start), metricsTags...)
 
 			// Separately record errors under `request.errors`
 			if err != nil {
@@ -89,7 +89,7 @@ func WrapMicroServerHandler(m Metrics, log log.Logger) server.HandlerWrapper {
 				}
 
 				metricsTags = append(metricsTags, fmt.Sprintf("code:%s", code.String()))
-				m.IncMonotonic("request.errors", metricsTags)
+				m.IncMonotonic("request.errors", metricsTags...)
 			}
 
 			return err

--- a/telemetry/metrics.go
+++ b/telemetry/metrics.go
@@ -42,48 +42,48 @@ type metrics struct {
 	prometheus Metrics
 }
 
-func (m *metrics) Gauge(name string, value float64, tags []string, rate float64) {
+func (m *metrics) Gauge(name string, value float64, rate float64, tags ...string) {
 	if m.datadog != nil {
-		m.datadog.Gauge(name, value, tags, rate)
+		m.datadog.Gauge(name, value, rate, tags...)
 	}
 	if m.prometheus != nil {
-		m.prometheus.Gauge(name, value, tags, rate)
+		m.prometheus.Gauge(name, value, rate, tags...)
 	}
 }
 
-func (m *metrics) Incr(name string, tags []string) {
+func (m *metrics) Incr(name string, tags ...string) {
 	if m.datadog != nil {
-		m.datadog.Incr(name, tags)
+		m.datadog.Incr(name, tags...)
 	}
 	if m.prometheus != nil {
-		m.prometheus.Incr(name, tags)
+		m.prometheus.Incr(name, tags...)
 	}
 }
 
-func (m *metrics) Decr(name string, tags []string) {
+func (m *metrics) Decr(name string, tags ...string) {
 	if m.datadog != nil {
-		m.datadog.Decr(name, tags)
+		m.datadog.Decr(name, tags...)
 	}
 	if m.prometheus != nil {
-		m.prometheus.Decr(name, tags)
+		m.prometheus.Decr(name, tags...)
 	}
 }
 
-func (m *metrics) Count(name string, value int64, tags []string) {
+func (m *metrics) Count(name string, value int64, tags ...string) {
 	if m.datadog != nil {
-		m.datadog.Count(name, value, tags)
+		m.datadog.Count(name, value, tags...)
 	}
 	if m.prometheus != nil {
-		m.prometheus.Count(name, value, tags)
+		m.prometheus.Count(name, value, tags...)
 	}
 }
 
-func (m *metrics) IncMonotonic(name string, tags []string) {
+func (m *metrics) IncMonotonic(name string, tags ...string) {
 	if m.datadog != nil {
-		m.datadog.IncMonotonic(name, tags)
+		m.datadog.IncMonotonic(name, tags...)
 	}
 	if m.prometheus != nil {
-		m.prometheus.IncMonotonic(name, tags)
+		m.prometheus.IncMonotonic(name, tags...)
 	}
 }
 
@@ -96,21 +96,21 @@ func (m *metrics) Error(errName string) {
 	}
 }
 
-func (m *metrics) Histogram(name string, value float64, tags []string, rate float64) {
+func (m *metrics) Histogram(name string, value float64, rate float64, tags ...string) {
 	if m.datadog != nil {
-		m.datadog.Histogram(name, value, tags, rate)
+		m.datadog.Histogram(name, value, rate, tags...)
 	}
 	if m.prometheus != nil {
-		m.prometheus.Histogram(name, value, tags, rate)
+		m.prometheus.Histogram(name, value, rate, tags...)
 	}
 }
 
-func (m *metrics) Time(name string, value time.Duration, tags []string) {
+func (m *metrics) Time(name string, value time.Duration, tags ...string) {
 	if m.datadog != nil {
-		m.datadog.Time(name, value, tags)
+		m.datadog.Time(name, value, tags...)
 	}
 	if m.prometheus != nil {
-		m.prometheus.Time(name, value, tags)
+		m.prometheus.Time(name, value, tags...)
 	}
 }
 

--- a/telemetry/prometheus/config.go
+++ b/telemetry/prometheus/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	// Default bucket count for histogram metrics
+	// Default bucket count for histogram metrics.
 	DefaultBucketCount = 10
 )
 

--- a/telemetry/prometheus/config.go
+++ b/telemetry/prometheus/config.go
@@ -6,18 +6,15 @@ import (
 )
 
 const (
-	// Default bucket count 1000 can satisfy the precision of p99 for most histogram stats.
-	DefaultBucketCount = 1000
+	// Default bucket count for histogram metrics
+	DefaultBucketCount = 10
 )
 
 type Config struct {
 	Enabled              bool
 	Namespace            string // optional
 	Subsystem            string // optional
-	HistogramBucketCount int    // Number of buckets for histogram, default to 1000
-	// Number of buckets for time buckets, default to 1000.
-	// The bucket size is 0.01s(10ms), so the maximum covered time range is 10ms * TimeBucketCount.
-	TimeBucketCount int
+	HistogramBucketCount int    // Number of linear buckets for histogram, default to 10
 }
 
 func (c *Config) Validate() error {

--- a/telemetry/prometheus/metrics.go
+++ b/telemetry/prometheus/metrics.go
@@ -173,6 +173,7 @@ func (p *metrics) Error(errName string) {
 
 // Histogram implements the Histogram method of the Metrics interface using HistogramVec with
 // linear buckets.
+// TODO: Support different types of buckets beyond linear buckets in future implementations.
 func (p *metrics) Histogram(name string, value float64, rate float64, tags ...string) {
 	if !p.cfg.Enabled {
 		return

--- a/telemetry/prometheus/metrics.go
+++ b/telemetry/prometheus/metrics.go
@@ -13,7 +13,7 @@ const (
 	initialVecCapacity = 32
 	tagSlices          = 2
 
-	// Constant for Summary (Percentile) metrics.
+	// Constant for Summary (quantile) metrics.
 	quantile50    = 0.5
 	quantile90    = 0.9
 	quantile99    = 0.99
@@ -194,7 +194,7 @@ func (p *metrics) Histogram(name string, value float64, rate float64, tags ...st
 }
 
 // Time implements the Time method of the Metrics interface using SummaryVec.
-// Currently the p50/p90/p99 percentile are recorded.
+// Currently the p50/p90/p99 quantile are recorded.
 func (p *metrics) Time(name string, value time.Duration, tags ...string) {
 	if !p.cfg.Enabled {
 		return

--- a/telemetry/prometheus/metrics.go
+++ b/telemetry/prometheus/metrics.go
@@ -169,7 +169,8 @@ func (p *metrics) Error(errName string) {
 	p.IncMonotonic("errors", fmt.Sprintf("type:%s", errName))
 }
 
-// Histogram implements the Histogram method of the Metrics interface using HistogramVec.
+// Histogram implements the Histogram method of the Metrics interface using HistogramVec with
+// linear buckets
 func (p *metrics) Histogram(name string, value float64, rate float64, tags ...string) {
 	if !p.cfg.Enabled {
 		return

--- a/telemetry/prometheus/metrics.go
+++ b/telemetry/prometheus/metrics.go
@@ -14,9 +14,11 @@ const (
 	tagSlices          = 2
 
 	// Constant for Summary (quantile) metrics.
-	quantile50    = 0.5
-	quantile90    = 0.9
-	quantile99    = 0.99
+	quantile50 = 0.5
+	quantile90 = 0.9
+	quantile99 = 0.99
+	// Usually the allowed relative error margin is 10%, and the absolute error margin is computed
+	// using (1 - quantile) * 10%. For example for p90, error margin is (1 - 90%) * 10% = 1% = 0.01.
 	errorMargin50 = 0.05
 	errorMargin90 = 0.01
 	errorMargin99 = 0.001
@@ -170,7 +172,7 @@ func (p *metrics) Error(errName string) {
 }
 
 // Histogram implements the Histogram method of the Metrics interface using HistogramVec with
-// linear buckets
+// linear buckets.
 func (p *metrics) Histogram(name string, value float64, rate float64, tags ...string) {
 	if !p.cfg.Enabled {
 		return
@@ -195,7 +197,7 @@ func (p *metrics) Histogram(name string, value float64, rate float64, tags ...st
 }
 
 // Time implements the Time method of the Metrics interface using SummaryVec.
-// Currently the p50/p90/p99 quantile are recorded.
+// Currently the p50/p90/p99 quantiles are recorded.
 func (p *metrics) Time(name string, value time.Duration, tags ...string) {
 	if !p.cfg.Enabled {
 		return

--- a/telemetry/prometheus/metrics.go
+++ b/telemetry/prometheus/metrics.go
@@ -45,7 +45,7 @@ func (p *metrics) Close() error {
 }
 
 // Gauge implements the Gauge method of the Metrics interface using GaugeVec.
-func (p *metrics) Gauge(name string, value float64, tags []string, _ float64) {
+func (p *metrics) Gauge(name string, value float64, _ float64, tags ...string) {
 	if !p.cfg.Enabled {
 		return
 	}
@@ -67,7 +67,7 @@ func (p *metrics) Gauge(name string, value float64, tags []string, _ float64) {
 }
 
 // Incr implements the Incr method of the Metrics interface using GaugeVec.
-func (p *metrics) Incr(name string, tags []string) {
+func (p *metrics) Incr(name string, tags ...string) {
 	if !p.cfg.Enabled {
 		return
 	}
@@ -89,7 +89,7 @@ func (p *metrics) Incr(name string, tags []string) {
 }
 
 // Decr implements the Decr method of the Metrics interface using GaugeVec.
-func (p *metrics) Decr(name string, tags []string) {
+func (p *metrics) Decr(name string, tags ...string) {
 	if !p.cfg.Enabled {
 		return
 	}
@@ -111,7 +111,7 @@ func (p *metrics) Decr(name string, tags []string) {
 }
 
 // Count implements the Count method of the Metrics interface using CounterVec.
-func (p *metrics) Count(name string, value int64, tags []string) {
+func (p *metrics) Count(name string, value int64, tags ...string) {
 	if !p.cfg.Enabled {
 		return
 	}
@@ -133,7 +133,7 @@ func (p *metrics) Count(name string, value int64, tags []string) {
 }
 
 // IncMonotonic implements the IncMonotonic method of the Metrics interface using CounterVec.
-func (p *metrics) IncMonotonic(name string, tags []string) {
+func (p *metrics) IncMonotonic(name string, tags ...string) {
 	if !p.cfg.Enabled {
 		return
 	}
@@ -156,11 +156,11 @@ func (p *metrics) IncMonotonic(name string, tags []string) {
 
 // Error implements the Error method of the Metrics interface using CounterVec.
 func (p *metrics) Error(errName string) {
-	p.IncMonotonic("errors", []string{fmt.Sprintf("type:%s", errName)})
+	p.IncMonotonic("errors", fmt.Sprintf("type:%s", errName))
 }
 
 // Histogram implements the Histogram method of the Metrics interface using HistogramVec.
-func (p *metrics) Histogram(name string, value float64, tags []string, rate float64) {
+func (p *metrics) Histogram(name string, value float64, rate float64, tags ...string) {
 	if !p.cfg.Enabled {
 		return
 	}
@@ -184,7 +184,7 @@ func (p *metrics) Histogram(name string, value float64, tags []string, rate floa
 }
 
 // Time implements the Time method of the Metrics interface using GaugeVec.
-func (p *metrics) Time(name string, value time.Duration, tags []string) {
+func (p *metrics) Time(name string, value time.Duration, tags ...string) {
 	if !p.cfg.Enabled {
 		return
 	}
@@ -212,7 +212,7 @@ func (p *metrics) Time(name string, value time.Duration, tags []string) {
 
 // Latency is a helper function to measure the latency of a routine.
 func (p *metrics) Latency(jobName string, start time.Time, tags ...string) {
-	p.Time(fmt.Sprintf("%s.latency", jobName), time.Since(start), tags)
+	p.Time(fmt.Sprintf("%s.latency", jobName), time.Since(start), tags...)
 }
 
 // parseTagsToLabelPairs converts a slice of tags in "key:value" format to two slices:

--- a/telemetry/types.go
+++ b/telemetry/types.go
@@ -5,20 +5,20 @@ import "time"
 // Metrics are used to record telemetry data. The primary types of telemetry data supported are
 // Gauges, Counters, and Histograms; the rest are convenience wrappers around these.
 type Metrics interface {
-	Gauge(name string, value float64, tags []string, rate float64)
+	Gauge(name string, value float64, rate float64, tags ...string)
 
-	Incr(name string, tags []string) // should be used if the metric can go up or down
-	Decr(name string, tags []string) // should be used if the metric can go up or down
+	Incr(name string, tags ...string) // should be used if the metric can go up or down
+	Decr(name string, tags ...string) // should be used if the metric can go up or down
 
-	Count(name string, value int64, tags []string)
+	Count(name string, value int64, tags ...string)
 
-	IncMonotonic(name string, tags []string) // should be used if the metric can go up only
+	IncMonotonic(name string, tags ...string) // should be used if the metric can go up only
 
 	Error(errName string)
 
-	Histogram(name string, value float64, tags []string, rate float64)
+	Histogram(name string, value float64, rate float64, tags ...string)
 
-	Time(name string, value time.Duration, tags []string)
+	Time(name string, value time.Duration, tags ...string)
 	Latency(jobName string, start time.Time, tags ...string)
 
 	Close() error


### PR DESCRIPTION
Tested locally by using the updated offchain-sdk to record latency metrics of BTS-indexer. So far so good. See the screenshots.

<img width="1474" alt="Screenshot 2024-06-18 at 1 51 02 PM" src="https://github.com/berachain/offchain-sdk/assets/168457646/f936bb11-ab4f-4c3d-bb65-569242dbfc77">
