### PR TITLE
Docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A framework for building off-chain services for EVM chains.
 
 ## 🚧 WARNING: UNDER CONSTRUCTION 🚧
 
-This project is work in progress and subject to frequent changes as we are still working on wiring up the final system.
+This project is a work in progress and subject to frequent changes as we are still working on wiring up the final system.
 It has not been audited for security purposes and should not be used in production yet.
 
 

--- a/baseapp/job_manager.go
+++ b/baseapp/job_manager.go
@@ -35,7 +35,7 @@ type JobManager struct {
 	producerCfg  *worker.PoolConfig
 	jobProducers *worker.Pool
 
-	// Job executors are a pool of workers that execute jobs. These workers
+	// Job executors are a pool of workers who execute jobs. These workers
 	// are fed jobs by the job producers.
 	executorCfg  *worker.PoolConfig
 	jobExecutors *worker.Pool

--- a/contracts/bindings/erc20.abigen.go
+++ b/contracts/bindings/erc20.abigen.go
@@ -391,7 +391,7 @@ func (it *IERC20ApprovalIterator) Next() bool {
 	}
 }
 
-// Error returns any retrieval or parsing error occurred during filtering.
+// Error returns any retrieval or parsing error that occurred during filtering.
 func (it *IERC20ApprovalIterator) Error() error {
 	return it.fail
 }
@@ -403,7 +403,7 @@ func (it *IERC20ApprovalIterator) Close() error {
 	return nil
 }
 
-// IERC20Approval represents a Approval event raised by the IERC20 contract.
+// IERC20Approval represents an Approval event raised by the IERC20 contract.
 type IERC20Approval struct {
 	Owner   common.Address
 	Spender common.Address

--- a/telemetry/README.md
+++ b/telemetry/README.md
@@ -11,7 +11,7 @@ Please see the following subsections for detailed configurations.
 
 ### Configuration
 
-The first step is adding a section in your config file. See following subsection for details. The
+The first step is adding a section in your config file. See the following subsection for details. The
 source code defining those configs can be found in [config.go](./datadog/config.go).
 
 #### Datadog Configs


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.