### PR TITLE
Remove duplicate ScriptBase import

### DIFF
--- a/contracts/lib/reference/lib/forge-std/src/Script.sol
+++ b/contracts/lib/reference/lib/forge-std/src/Script.sol
@@ -17,7 +17,6 @@ import {StdUtils} from "./StdUtils.sol";
 import {VmSafe} from "./Vm.sol";
 
 // 📦 BOILERPLATE
-import {ScriptBase} from "./Base.sol";
 
 // ⭐️ SCRIPT
 abstract contract Script is StdChains, StdCheatsSafe, StdUtils, ScriptBase {


### PR DESCRIPTION

## Changes Made
File: `contracts/lib/openzeppelin-contracts/lib/forge-std/src/Script.sol`

Before:
![image](https://github.com/user-attachments/assets/5c7b563f-d128-4f10-88aa-b2be392c19ef)

After:
![image](https://github.com/user-attachments/assets/08f39684-702e-4ced-bfd4-f75b2d4c906a)

## Reason for Changes
- Removed duplicate import of ScriptBase to improve code organization
- All imports are now properly grouped under MODULES section
- Maintains same functionality while reducing code duplication

## Testing
- Compilation succeeds
- All existing tests pass
- No new warnings introduced